### PR TITLE
fix: recover browsers stuck on expired-domain service worker

### DIFF
--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -1,12 +1,65 @@
 // eslint-disable-next-line import-x/no-unresolved
 import { registerSW } from "virtual:pwa-register";
 
-registerSW({
-  immediate: true,
-  onRegisteredSW(swScriptUrl) {
-    console.log(`SW registered: `, swScriptUrl);
-  },
-  onOfflineReady() {
-    console.log(`PWA application ready to work offline`);
+/**
+ * Recovery for a stale, foreign service worker.
+ *
+ * While the domain was expired it served a parking page that registered its
+ * own service worker at this origin (scope "/"). That worker redirects the
+ * root navigation to /lander, which no longer exists, and it keeps running in
+ * affected browsers until explicitly removed.
+ *
+ * The parking worker was a Next.js build: it precaches `/_next/...` URLs, a
+ * signature our Astro site never produces. If we find that signature in the
+ * Cache Storage, we unregister every worker, clear the caches, and reload once
+ * (guarded by sessionStorage so it can never loop).
+ */
+const RECOVERY_FLAG = `sw-recovery-reloaded`;
+
+async function hasForeignCache(): Promise<boolean> {
+  if (!(`caches` in window)) return false;
+  const keys = await caches.keys();
+  for (const key of keys) {
+    const cache = await caches.open(key);
+    const requests = await cache.keys();
+    if (
+      requests.some((req) => new URL(req.url).pathname.startsWith(`/_next/`))
+    ) {
+      return true;
+    }
   }
-});
+  return false;
+}
+
+async function recoverFromForeignWorker(): Promise<boolean> {
+  if (sessionStorage.getItem(RECOVERY_FLAG)) return false; // already tried once
+  if (!navigator.serviceWorker.controller) return false; // nothing controlling us
+  if (!(await hasForeignCache())) return false; // controller looks like ours
+
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  await Promise.all(registrations.map(async (r) => r.unregister()));
+  const keys = await caches.keys();
+  await Promise.all(keys.map(async (k) => caches.delete(k)));
+  sessionStorage.setItem(RECOVERY_FLAG, `1`);
+  // Bypass any cached redirect with a hard, cache-busting navigation.
+  window.location.replace(`/?sw=${Date.now()}`);
+  return true;
+}
+
+async function init(): Promise<void> {
+  if (`serviceWorker` in navigator && (await recoverFromForeignWorker())) {
+    return; // reloading; don't register over a worker we're tearing down
+  }
+
+  registerSW({
+    immediate: true,
+    onRegisteredSW(swScriptUrl) {
+      console.log(`SW registered: `, swScriptUrl);
+    },
+    onOfflineReady() {
+      console.log(`PWA application ready to work offline`);
+    }
+  });
+}
+
+void init();


### PR DESCRIPTION
## Problem

While `crimsonwitnesses.com` was expired, it served a parking page that registered its own service worker at this origin (scope `/`). That worker redirects the root navigation to `/lander` — which now returns 404. The domain is renewed and the site is healthy, but **browsers that visited during the lapse keep running the parking worker** and get redirected, even after clearing site data (the worker re-asserts control).

## Diagnosis

Confirmed the production deployment is correct:
- `curl` and a fresh Chrome context both load the real Astro site at `/` (HTTP 200, no redirect).
- The deployed `sw.js` is the clean Workbox worker our build generates (no `/lander`, no `/_next`).
- `/lander` returns 404 on the server.

So the redirect is **purely a stale, foreign service worker cached client-side** — not our code.

## Fix

On load, `src/pwa.ts` detects the parking worker by its **Next.js cache signature** (it precaches `/_next/...` URLs, which our Astro site never produces). When found, it unregisters all workers, clears Cache Storage, and hard-reloads once.

Safety:
- A `sessionStorage` guard makes the reload impossible to loop.
- The recovery only runs when a worker is actually controlling the page **and** a `/_next/` cache exists, so our own clean worker is never torn down.

Verified the discriminator in-browser: returns `false` for a clean session, `true` only with a planted `/_next/` cache, `false` again after cleanup.

## Scope

`src/pwa.ts` only. `vp check` clean; production build succeeds with the PWA integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)